### PR TITLE
Compatibility with 32 bit boards

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=SparkFun Electronics
 maintainer=SparkFun Electronics
 sentence=An Arduino library for interfacing with the SparkFun Triple Axis Accelerometer Breakout - ADXL345 
 paragraph=An Arduino library for interfacing with the SparkFun Triple Axis Accelerometer Breakout - ADXL345 
-category=sensors
+category=Sensors
 url=https://github.com/sparkfun/SparkFun_ADXL345_Arduino_Library
 architectures=*

--- a/src/SparkFun_ADXL345.cpp
+++ b/src/SparkFun_ADXL345.cpp
@@ -74,9 +74,9 @@ void ADXL345::readAccel(int *x, int *y, int *z) {
 	readFrom(ADXL345_DATAX0, ADXL345_TO_READ, _buff);	// Read Accel Data from ADXL345
 	
 	// Each Axis @ All g Ranges: 10 Bit Resolution (2 Bytes)
-	*x = (((int)_buff[1]) << 8) | _buff[0];   
-	*y = (((int)_buff[3]) << 8) | _buff[2];
-	*z = (((int)_buff[5]) << 8) | _buff[4];
+	*x = (int16_t)((((int)_buff[1]) << 8) | _buff[0]);
+	*y = (int16_t)((((int)_buff[3]) << 8) | _buff[2]);
+	*z = (int16_t)((((int)_buff[5]) << 8) | _buff[4]);
 }
 
 void ADXL345::get_Gxyz(double *xyz){


### PR DESCRIPTION
This library currently only works on 8 bit AVR, due to an assumption that signed int is 16 bits.  On 32 bit boards, negative acceleration reads as large positive numbers.

This pull request just adds a cast to int16_t, to allow 32 bit processors to get the same result.