### PR TITLE
Addition of FIFO Control and Status

### DIFF
--- a/src/SparkFun_ADXL345.cpp
+++ b/src/SparkFun_ADXL345.cpp
@@ -819,3 +819,34 @@ void print_byte(byte val){
 		Serial.print(val >> i & 1, BIN);
 	}
 }
+
+/********************** FIFO Control and Status *********************/
+/*                        Activates FIFO Modes                      */
+void ADXL345::setFIFOMode(String FIFOMode) {
+	if (FIFOMode == "FIFO") {
+		writeTo(ADXL345_FIFO_CTL, 95);
+	} else if (FIFOMode == "Stream") {
+		writeTo(ADXL345_FIFO_CTL, 159);
+	} else if(FIFOMode == "Trigger") {
+		writeTo(ADXL345_FIFO_CTL, 223);
+	} else { //Bypass Mode
+		writeTo(ADXL345_FIFO_CTL, 31);
+	}
+}
+
+byte ADXL345::getFIFOMode() {
+	byte control = 0;
+	for(int i=0; i<8; i++) {
+   		control |= getRegisterBit(ADXL345_FIFO_CTL, i) << i;
+	}
+	return control;
+}
+
+//returns number of data values stored in FIFO
+byte ADXL345::getFIFOStatus() {
+	byte numEntries = 0;
+	for(int i=0; i<6; i++) {
+   		numEntries |= getRegisterBit(ADXL345_FIFO_STATUS, i) << i;
+	}
+	return numEntries;
+}

--- a/src/SparkFun_ADXL345.h
+++ b/src/SparkFun_ADXL345.h
@@ -218,6 +218,10 @@ public:
 	void setJustifyBit(bool justifyBit);
 	void printAllRegister();
 	
+	void setFIFOMode(String FIFOMode);
+	byte getFIFOMode();
+	byte getFIFOStatus();
+	
 private:
 	void writeTo(byte address, byte val);
 	void writeToI2C(byte address, byte val);


### PR DESCRIPTION
This library does not have methods to enable FIFO and select one of its modes. 
The setFIFOMode will select one of the four available modes - Bypass, FIFO, Stream and Trigger.
The getFIFOMode will return the byte set in the FIFO_CTL register.
The getFIFOStatus will return the number of data values stored in FIFO.